### PR TITLE
feat(release): Add Homebrew tap publishing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,6 +64,21 @@ changelog:
     - title: Others
       order: 999
 
+brews:
+  - name: claude-history
+    repository:
+      owner: randlee
+      name: homebrew-tap
+      token: "{{ .Env.GITHUB_TOKEN }}"
+    homepage: "https://github.com/randlee/claude-history"
+    description: "CLI tool for programmatic access to Claude Code's agent history storage"
+    license: "MIT"
+    folder: Formula
+    install: |
+      bin.install "claude-history"
+    test: |
+      system "#{bin}/claude-history", "--version"
+
 release:
   github:
     owner: randlee
@@ -78,7 +93,13 @@ release:
 
     ### Installation
 
-    **macOS/Linux:**
+    **Homebrew:**
+    ```bash
+    brew tap randlee/tap
+    brew install claude-history
+    ```
+
+    **Install Script (macOS/Linux):**
     ```bash
     curl -fsSL https://raw.githubusercontent.com/randlee/claude-history/main/install.sh | bash
     ```
@@ -86,10 +107,4 @@ release:
     **Go install:**
     ```bash
     go install github.com/randlee/claude-history@{{.Tag}}
-    ```
-
-    **Homebrew:**
-    ```bash
-    brew tap randlee/claude-history
-    brew install claude-history
     ```

--- a/docs/HOMEBREW_SETUP.md
+++ b/docs/HOMEBREW_SETUP.md
@@ -1,0 +1,66 @@
+# Homebrew Tap Setup
+
+This document explains the Homebrew tap configuration for claude-history.
+
+## What is a Homebrew Tap?
+
+A "tap" is a third-party repository of Homebrew formulas. Users can add your tap and install your tool with:
+
+```bash
+brew tap randlee/tap
+brew install claude-history
+```
+
+## How It Works
+
+1. **Repository**: GoReleaser automatically creates/updates `github.com/randlee/homebrew-tap`
+2. **Formula**: Creates `Formula/claude-history.rb` with installation instructions
+3. **Auto-update**: Each release updates the formula with new version/checksums
+
+## Configuration
+
+See `.goreleaser.yml` section:
+
+```yaml
+brews:
+  - name: claude-history
+    repository:
+      owner: randlee
+      name: homebrew-tap
+```
+
+## First-Time Setup
+
+GoReleaser will **automatically create** the `homebrew-tap` repository on first release.
+
+**No manual setup required!**
+
+## User Installation
+
+After the next release (v0.2.0+), users install with:
+
+```bash
+# Add the tap (one-time)
+brew tap randlee/tap
+
+# Install claude-history
+brew install claude-history
+
+# Update to latest
+brew upgrade claude-history
+```
+
+## Verification
+
+After the next release, verify:
+
+1. Repository exists: https://github.com/randlee/homebrew-tap
+2. Formula exists: `homebrew-tap/Formula/claude-history.rb`
+3. Users can install: `brew tap randlee/tap && brew install claude-history`
+
+## Notes
+
+- The tap name is `randlee/tap` (short form of `randlee/homebrew-tap`)
+- GoReleaser handles all formula updates automatically
+- Works on both macOS and Linux
+- Formula includes SHA256 checksums for security


### PR DESCRIPTION
## Summary

Adds Homebrew tap publishing to GoReleaser for easier installation on macOS/Linux.

## Changes

**`.goreleaser.yml`**:
- Added `brews` section for Homebrew formula generation
- Target repository: `randlee/homebrew-tap` (auto-created by GoReleaser)
- Updated release notes to prioritize Homebrew installation
- Formula includes test command for verification

**`docs/HOMEBREW_SETUP.md`**:
- Documentation on how Homebrew tap works
- User installation instructions
- First-time setup notes

## User Installation (After Next Release)

```bash
brew tap randlee/tap
brew install claude-history
```

## How It Works

1. On release, GoReleaser automatically:
   - Creates/updates `github.com/randlee/homebrew-tap` repository
   - Generates `Formula/claude-history.rb` with installation instructions
   - Updates formula with new version and SHA256 checksums

2. Users add the tap once, then install/update normally:
   - `brew tap randlee/tap` (one-time)
   - `brew install claude-history`
   - `brew upgrade claude-history` (for updates)

## Benefits

- ✅ **No Homebrew account required** - Just uses GitHub
- ✅ **Auto-maintained** - GoReleaser updates formula on each release
- ✅ **Works on macOS & Linux** - Broader reach than install script alone
- ✅ **Standard developer workflow** - Most macOS devs use Homebrew
- ✅ **Secure** - Formulas include SHA256 checksums

## Testing

After next release (v0.2.0), verify:
- Repository exists: https://github.com/randlee/homebrew-tap
- Formula works: `brew tap randlee/tap && brew install claude-history`
- Version correct: `claude-history --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)